### PR TITLE
Initial setup for i18n translations

### DIFF
--- a/healthmate/settings.py
+++ b/healthmate/settings.py
@@ -64,6 +64,7 @@ AUTHENTICATION_BACKENDS = (
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,39 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-11-29 15:27+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: healthmate/services/models.py:22
+msgid "Service Name"
+msgstr "Nombre del Servicio"
+
+#: healthmate/services/models.py:23
+msgid "This name will be used to identify your service."
+msgstr ""
+
+#: healthmate/services/models.py:27
+msgid "Represented as (longitude, latitude)"
+msgstr ""
+
+#: templates/home.html:8
+msgid "Find a service"
+msgstr ""
+
+#: templates/home.html:9
+msgid "Add a service"
+msgstr "Añadir Un Servicio"


### PR DESCRIPTION
### Setup instructions

**Ensure `gettext` is installed**

> `apt-get install gettext`

**Create new locale / .po file (e.g. spanish)**

> `./manage.py makemessages -l es`

**Update existing .po files** (nb. will comment out any custom keywords not present in code so uncomment DB-driven terms before compile/commit):

>  `./manage.py makemessages`

**Compile changes, creates .mo file**

>  `./manage.py compilemessages`
### How does user change locale?

**Use language session key**

> `request.session[settings.LANGUAGE_SESSION_KEY] = 'es'`
